### PR TITLE
Improve Printer Compatibility - Remove Forced Print Mode

### DIFF
--- a/src/zplgrf/__init__.py
+++ b/src/zplgrf/__init__.py
@@ -322,7 +322,7 @@ class GRF(object):
 
     def to_zpl(
         self, quantity=1, pause_and_cut=0, override_pause=False,
-        print_mode='C', print_orientation='N', media_tracking='Y', **kwargs
+        print_orientation='N', media_tracking='Y', **kwargs
     ):
         """
         The most basic ZPL to print the GRF. Since ZPL printers are stateful
@@ -331,7 +331,6 @@ class GRF(object):
         zpl = [
             self.to_zpl_line(**kwargs),  # Download image to printer
             '^XA',  # Start Label Format
-            '^MM%s,Y' % print_mode,
             '^PO%s' % print_orientation,
             '^MN%s' % media_tracking,
             '^FO0,0',  # Field Origin to 0,0


### PR DESCRIPTION
This pull request aims to improve printer compatibility in the __init__.py file by removing the forced print mode and allowing the print mode to be determined by the printer settings. 
This change addresses the following:

- **Removal of forced print mode**: The print_mode parameter is no longer hardcoded as "C". Instead, the print mode will depend on the printer settings, ensuring greater flexibility and compatibility.

- **Prevention of label feed issues**: The previous forced print mode caused the label to feed back, resulting in potential paint residue on the label. By removing the forced print mode, this issue is resolved, eliminating the risk of paint residue.

Please review and consider merging it into the main branch.